### PR TITLE
Add docs and tests for margin calculations

### DIFF
--- a/app.py
+++ b/app.py
@@ -74,38 +74,37 @@ T = PL if lang == "Polski" else EN
 # ------------------ Funkcje matematyczne -------------------
 
 def licz_marze_z_ceny(tkw: Decimal, cena: Decimal) -> Decimal:
-    """Calculate margin fraction from unit cost and price.
+    """Return margin as a fraction of the selling price.
 
     Parameters
     ----------
     tkw : Decimal
         Unit production cost.
     cena : Decimal
-        Sale price per unit.
+        Selling price per unit.
 
     Returns
     -------
     Decimal
-        Margin expressed as a fraction of the price. Returns ``Decimal('0')`` when
-        the price is zero.
+        Margin fraction. ``Decimal('0')`` is returned when ``cena`` is zero.
     """
     return (cena - tkw) / cena if cena else Decimal("0")
 
 def cena_z_marzy(tkw: Decimal, marza: Decimal) -> Decimal:
-    """Calculate sale price required for a given margin.
+    """Return sale price required to achieve a given margin.
 
     Parameters
     ----------
     tkw : Decimal
         Unit production cost.
     marza : Decimal
-        Desired margin expressed as a fraction (e.g. ``0.25`` for 25%).
+        Desired margin expressed as a fraction (``0.25`` means 25%).
 
     Returns
     -------
     Decimal
-        Sale price that yields the desired margin. Returns ``Decimal('0')`` when the
-        provided margin is ``1`` or greater.
+        Price that yields ``marza`` margin. ``Decimal('0')`` is returned for
+        margins greater than or equal to ``1``.
     """
     return tkw / (Decimal("1") - marza) if marza < Decimal("1") else Decimal("0")
 

--- a/tests/test_calculations.py
+++ b/tests/test_calculations.py
@@ -1,0 +1,54 @@
+import ast
+import unittest
+from decimal import Decimal
+from pathlib import Path
+
+
+def _load_functions():
+    """Load calculation functions from app.py without running Streamlit UI."""
+    tree = ast.parse(Path(__file__).resolve().parents[1].joinpath('app.py').read_text(), filename='app.py')
+    namespace = {'Decimal': Decimal}
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name in {'licz_marze_z_ceny', 'cena_z_marzy'}:
+            mod = ast.Module(body=[node], type_ignores=[])
+            exec(compile(mod, filename='app.py', mode='exec'), namespace)
+    return namespace['licz_marze_z_ceny'], namespace['cena_z_marzy']
+
+
+licz_marze_z_ceny, cena_z_marzy = _load_functions()
+
+
+class TestMarginFunctions(unittest.TestCase):
+    def test_licz_marze_basic(self):
+        self.assertEqual(
+            licz_marze_z_ceny(Decimal('50'), Decimal('100')),
+            Decimal('0.5')
+        )
+
+    def test_licz_marze_zero_price(self):
+        self.assertEqual(
+            licz_marze_z_ceny(Decimal('50'), Decimal('0')),
+            Decimal('0')
+        )
+
+    def test_licz_marze_negative(self):
+        self.assertEqual(
+            licz_marze_z_ceny(Decimal('80'), Decimal('60')),
+            Decimal('-0.3333333333333333333333333333')
+        )
+
+    def test_cena_z_marzy_basic(self):
+        self.assertEqual(
+            cena_z_marzy(Decimal('50'), Decimal('0.2')),
+            Decimal('62.5')
+        )
+
+    def test_cena_z_marzy_over_one(self):
+        self.assertEqual(
+            cena_z_marzy(Decimal('10'), Decimal('1')),
+            Decimal('0')
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- document calculation helpers
- add minimal `unittest` suite

## Testing
- `python -m unittest discover -s tests -p "test*.py" -v`

------
https://chatgpt.com/codex/tasks/task_e_68449f77cc88832cb9c1ea74f376aa98