### PR TITLE
Add examples in docstrings and extend tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -74,7 +74,7 @@ T = PL if lang == "Polski" else EN
 # ------------------ Funkcje matematyczne -------------------
 
 def licz_marze_z_ceny(tkw: Decimal, cena: Decimal) -> Decimal:
-    """Return margin as a fraction of the selling price.
+    """Return the margin as a fraction of ``cena``.
 
     Parameters
     ----------
@@ -86,25 +86,36 @@ def licz_marze_z_ceny(tkw: Decimal, cena: Decimal) -> Decimal:
     Returns
     -------
     Decimal
-        Margin fraction. ``Decimal('0')`` is returned when ``cena`` is zero.
+        Margin expressed as ``(cena - tkw) / cena``. ``Decimal('0')`` is
+        returned when ``cena`` equals ``0``.
+
+    Examples
+    --------
+    >>> licz_marze_z_ceny(Decimal('50'), Decimal('100'))
+    Decimal('0.5')
     """
     return (cena - tkw) / cena if cena else Decimal("0")
 
 def cena_z_marzy(tkw: Decimal, marza: Decimal) -> Decimal:
-    """Return sale price required to achieve a given margin.
+    """Return the sale price required to achieve ``marza``.
 
     Parameters
     ----------
     tkw : Decimal
         Unit production cost.
     marza : Decimal
-        Desired margin expressed as a fraction (``0.25`` means 25%).
+        Desired margin expressed as a fraction (``0.25`` means ``25%``).
 
     Returns
     -------
     Decimal
         Price that yields ``marza`` margin. ``Decimal('0')`` is returned for
         margins greater than or equal to ``1``.
+
+    Examples
+    --------
+    >>> cena_z_marzy(Decimal('50'), Decimal('0.2'))
+    Decimal('62.5')
     """
     return tkw / (Decimal("1") - marza) if marza < Decimal("1") else Decimal("0")
 

--- a/tests/test_calculations.py
+++ b/tests/test_calculations.py
@@ -37,6 +37,12 @@ class TestMarginFunctions(unittest.TestCase):
             Decimal('-0.3333333333333333333333333333')
         )
 
+    def test_licz_marze_zero_margin(self):
+        self.assertEqual(
+            licz_marze_z_ceny(Decimal('50'), Decimal('50')),
+            Decimal('0')
+        )
+
     def test_cena_z_marzy_basic(self):
         self.assertEqual(
             cena_z_marzy(Decimal('50'), Decimal('0.2')),
@@ -47,6 +53,12 @@ class TestMarginFunctions(unittest.TestCase):
         self.assertEqual(
             cena_z_marzy(Decimal('10'), Decimal('1')),
             Decimal('0')
+        )
+
+    def test_cena_z_marzy_zero_margin(self):
+        self.assertEqual(
+            cena_z_marzy(Decimal('10'), Decimal('0')),
+            Decimal('10')
         )
 
 


### PR DESCRIPTION
## Summary
- clarify docstrings for `licz_marze_z_ceny` and `cena_z_marzy`
- include example usage in docstrings
- add additional unit tests for zero margin cases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a19a2f20832c8d4edfe0172809f9