### PR TITLE
Fix Decimal and float mismatch in profit calculation

### DIFF
--- a/app.py
+++ b/app.py
@@ -213,8 +213,9 @@ with tab_obnizka:
             st.stop()
 
         if _entered("marza_stara"):
-            cena_stara = float(
-                cena_z_marzy(Decimal(tkw), Decimal(marza_stara) / Decimal(100))
+            cena_stara = cena_z_marzy(
+                tkw,
+                marza_stara / Decimal(100),
             )
         elif not _entered("cena_stara"):
             st.error(T["err_pair_old"])
@@ -225,8 +226,9 @@ with tab_obnizka:
             ) * 100
 
         if _entered("marza_nowa"):
-            cena_nowa = float(
-                cena_z_marzy(Decimal(tkw), Decimal(marza_nowa) / Decimal(100))
+            cena_nowa = cena_z_marzy(
+                tkw,
+                marza_nowa / Decimal(100),
             )
         elif not _entered("cena_nowa"):
             st.error(T["err_pair_new"])


### PR DESCRIPTION
## Summary
- fix mixing `float` and `Decimal` in discount tab
- keep calculations in `Decimal`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68453d127a44832cba75b82e2fc127e3