### PR TITLE
Round prices from margin calculations

### DIFF
--- a/app.py
+++ b/app.py
@@ -247,7 +247,7 @@ with tab_obnizka:
             cena_stara = cena_z_marzy(
                 tkw,
                 marza_stara / Decimal(100),
-            )
+            ).quantize(Decimal("0.01"))
         elif not _entered("cena_stara"):
             st.error(T["err_pair_old"])
             st.stop()
@@ -260,7 +260,7 @@ with tab_obnizka:
             cena_nowa = cena_z_marzy(
                 tkw,
                 marza_nowa / Decimal(100),
-            )
+            ).quantize(Decimal("0.01"))
         elif not _entered("cena_nowa"):
             st.error(T["err_pair_new"])
             st.stop()
@@ -348,6 +348,7 @@ with tab_szybki:
         elif _entered("tkw_m") and _entered("marza_m"):
             cena_m = float(
                 cena_z_marzy(Decimal(tkw_m), Decimal(marza_m) / Decimal(100))
+                .quantize(Decimal("0.01"))
             )
         elif _entered("cena_m") and _entered("marza_m"):
             tkw_m = cena_m * (1 - marza_m / 100)

--- a/tests/test_calculations.py
+++ b/tests/test_calculations.py
@@ -50,6 +50,18 @@ class TestMarginFunctions(unittest.TestCase):
             Decimal('10')
         )
 
+    def test_total_loss_quantized(self):
+        tkw = Decimal('80')
+        marza_stara = Decimal('0.4')
+        marza_nowa = Decimal('0.2')
+        qty = 100
+        cena_stara = cena_z_marzy(tkw, marza_stara).quantize(Decimal('0.01'))
+        cena_nowa = cena_z_marzy(tkw, marza_nowa).quantize(Decimal('0.01'))
+        zysk_stary = cena_stara - tkw
+        zysk_nowy = cena_nowa - tkw
+        strata = (zysk_stary - zysk_nowy) * qty
+        self.assertEqual(strata, Decimal('3333'))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- round prices calculated from margins to `Decimal('0.01')`
- round quick calculator price to the same precision
- test margin loss scenario

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68454422f554832c8ca34bedbadc00ab