### PR TITLE
Fix radio label warning

### DIFF
--- a/app.py
+++ b/app.py
@@ -206,11 +206,12 @@ def _on_tab_change() -> None:
 
 
 st.radio(
-    label="",
+    label="Calculator mode",
     options=tab_labels,
     index=0 if st.session_state["selected_tab"] == "discount" else 1,
     key="tab_choice",
     on_change=_on_tab_change,
+    label_visibility="collapsed",
 )
 
 # ========= Zakładka 1: obniżka marży / ceny ================


### PR DESCRIPTION
## Summary
- provide label for tab radio and collapse it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68454f38aa68832cb183d4c917730bf1