### PR TITLE
Replace deprecated Streamlit function

### DIFF
--- a/app.py
+++ b/app.py
@@ -202,7 +202,7 @@ def _on_tab_change() -> None:
         clear_quick_all()
         st.session_state["selected_tab"] = new_key
         st.query_params.update({"tab": new_key})
-        st.experimental_rerun()
+        st.rerun()
 
 
 st.radio(


### PR DESCRIPTION
## Summary
- update `_on_tab_change` handler to use `st.rerun()` instead of the deprecated
  `st.experimental_rerun()`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845533b90dc832c8b521cfcf609ec25