### PR TITLE
Make project importable as a package

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,4 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))

--- a/tests/test_calculations.py
+++ b/tests/test_calculations.py
@@ -1,9 +1,6 @@
 import unittest
 from decimal import Decimal
-from pathlib import Path
-import sys
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 from calculator import licz_marze_z_ceny, cena_z_marzy
 
 

--- a/tests/test_to_decimal.py
+++ b/tests/test_to_decimal.py
@@ -1,9 +1,4 @@
 from decimal import Decimal
-from pathlib import Path
-import sys
-
-# Allow importing from repo root
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from utils import _to_decimal
 

--- a/tests/test_to_int.py
+++ b/tests/test_to_int.py
@@ -1,9 +1,3 @@
-from pathlib import Path
-import sys
-
-# Allow importing from repo root
-sys.path.append(str(Path(__file__).resolve().parents[1]))
-
 from utils import _to_int
 
 


### PR DESCRIPTION
## Summary
- add empty `__init__.py` at repo root
- remove `sys.path` hacks from tests
- keep a single path adjustment in `tests/__init__.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684557df4800832ca6c77054f266e238