### PR TITLE
Handle invalid numeric input gracefully

### DIFF
--- a/app.py
+++ b/app.py
@@ -203,7 +203,7 @@ if st.session_state["selected_tab"] == "discount":
 
     col_a, col_or1, col_b = st.columns([1, 0.15, 1])
     with col_a:
-        tkw = _to_decimal(st.text_input(T["tkw"], key="tkw"))
+        tkw = _to_decimal(st.text_input(T["tkw"], key="tkw"), none_on_error=True)
         sub_a1, sub_a2, sub_a3 = st.columns([1,1,1])
         with sub_a2:
             st.button(T["btn_clear"], key="clr_tkw", on_click=_clear_field, args=("tkw", INITIAL_DISCOUNT))
@@ -213,14 +213,14 @@ if st.session_state["selected_tab"] == "discount":
             unsafe_allow_html=True,
         )
     with col_b:
-        cena_stara = _to_decimal(st.text_input(T["price"], key="cena_stara"))
+        cena_stara = _to_decimal(st.text_input(T["price"], key="cena_stara"), none_on_error=True)
         sub_b1, sub_b2, sub_b3 = st.columns([1,1,1])
         with sub_b2:
             st.button(T["btn_clear"], key="clr_cena_stara", on_click=_clear_field, args=("cena_stara", INITIAL_DISCOUNT))
 
     col_c, col_or2, col_d = st.columns([1, 0.15, 1])
     with col_c:
-        marza_stara = _to_decimal(st.text_input(T["old_margin"], key="marza_stara"))
+        marza_stara = _to_decimal(st.text_input(T["old_margin"], key="marza_stara"), none_on_error=True)
         sub_c1, sub_c2, sub_c3 = st.columns([1,1,1])
         with sub_c2:
             st.button(T["btn_clear"], key="clr_marza_stara", on_click=_clear_field, args=("marza_stara", INITIAL_DISCOUNT))
@@ -230,19 +230,19 @@ if st.session_state["selected_tab"] == "discount":
             unsafe_allow_html=True,
         )
     with col_d:
-        cena_nowa = _to_decimal(st.text_input(T["new_price"], key="cena_nowa"))
+        cena_nowa = _to_decimal(st.text_input(T["new_price"], key="cena_nowa"), none_on_error=True)
         sub_d1, sub_d2, sub_d3 = st.columns([1,1,1])
         with sub_d2:
             st.button(T["btn_clear"], key="clr_cena_nowa", on_click=_clear_field, args=("cena_nowa", INITIAL_DISCOUNT))
 
     col_e, col_f = st.columns([1, 1])
     with col_e:
-        marza_nowa = _to_decimal(st.text_input(T["new_margin"], key="marza_nowa"))
+        marza_nowa = _to_decimal(st.text_input(T["new_margin"], key="marza_nowa"), none_on_error=True)
         sub_e1, sub_e2, sub_e3 = st.columns([1,1,1])
         with sub_e2:
             st.button(T["btn_clear"], key="clr_marza_nowa", on_click=_clear_field, args=("marza_nowa", INITIAL_DISCOUNT))
     with col_f:
-        ilosc_stara = _to_int(st.text_input(T["qty"], key="ilosc_stara"))
+        ilosc_stara = _to_int(st.text_input(T["qty"], key="ilosc_stara"), none_on_error=True)
         sub_f1, sub_f2, sub_f3 = st.columns([1,1,1])
         with sub_f2:
             st.button(T["btn_clear"], key="clr_ilosc_stara", on_click=_clear_field, args=("ilosc_stara", INITIAL_DISCOUNT))
@@ -254,6 +254,10 @@ if st.session_state["selected_tab"] == "discount":
         st.button(T["btn_example"], key="example_discount", on_click=load_discount_example)
 
     if st.button(T["btn_discount"], key="discount_btn"):
+        if None in (tkw, cena_stara, marza_stara, cena_nowa, marza_nowa, ilosc_stara):
+            st.error("Invalid input")
+            st.stop()
+
         if not _entered("tkw") or not _entered("ilosc_stara"):
             st.error(T["err_fill"])
             st.stop()
@@ -316,7 +320,7 @@ elif st.session_state["selected_tab"] == "quick":
 
     col_tkw, col_or_a, col_price, col_or_b, col_margin = st.columns([1, 0.13, 1, 0.13, 1])
     with col_tkw:
-        tkw_m = _to_decimal(st.text_input(T["tkw"], key="tkw_m"))
+        tkw_m = _to_decimal(st.text_input(T["tkw"], key="tkw_m"), none_on_error=True)
         sub_q1, sub_q2, sub_q3 = st.columns([1,1,1])
         with sub_q2:
             st.button(T["btn_clear"], key="clr_tkw_m", on_click=_clear_field, args=("tkw_m", INITIAL_QUICK))
@@ -326,7 +330,7 @@ elif st.session_state["selected_tab"] == "quick":
             unsafe_allow_html=True,
         )
     with col_price:
-        cena_m = _to_decimal(st.text_input(T["price"], key="cena_m"))
+        cena_m = _to_decimal(st.text_input(T["price"], key="cena_m"), none_on_error=True)
         sub_q4, sub_q5, sub_q6 = st.columns([1,1,1])
         with sub_q5:
             st.button(T["btn_clear"], key="clr_cena_m", on_click=_clear_field, args=("cena_m", INITIAL_QUICK))
@@ -341,7 +345,7 @@ elif st.session_state["selected_tab"] == "quick":
                 T["new_margin"].replace("Nowa ", "").replace("New ", "").capitalize(),
                 key="marza_m",
             )
-        )
+        , none_on_error=True)
         sub_q7, sub_q8, sub_q9 = st.columns([1,1,1])
         with sub_q8:
             st.button(T["btn_clear"], key="clr_marza_m", on_click=_clear_field, args=("marza_m", INITIAL_QUICK))
@@ -353,6 +357,10 @@ elif st.session_state["selected_tab"] == "quick":
         st.button(T["btn_example"], key="example_quick", on_click=load_quick_example)
 
     if st.button(T["btn_quick"], key="quick_btn"):
+        if None in (tkw_m, cena_m, marza_m):
+            st.error("Invalid input")
+            st.stop()
+
         pola = [_entered("tkw_m"), _entered("cena_m"), _entered("marza_m")]
         if sum(pola) < 2:
             st.error(T["err_two_values"])

--- a/tests/test_to_decimal.py
+++ b/tests/test_to_decimal.py
@@ -17,3 +17,13 @@ def test_to_decimal_invalid_string():
     assert _to_decimal("abc") == Decimal("0")
     assert _to_decimal("1,000.50") == Decimal("0")
 
+
+def test_to_decimal_invalid_string_none():
+    assert _to_decimal("abc", none_on_error=True) is None
+    assert _to_decimal("1,000.50", none_on_error=True) is None
+
+
+def test_to_decimal_valid_with_flag():
+    assert _to_decimal("10.5", none_on_error=True) == Decimal("10.5")
+    assert _to_decimal("10,5", none_on_error=True) == Decimal("10.5")
+

--- a/tests/test_to_int.py
+++ b/tests/test_to_int.py
@@ -12,3 +12,14 @@ def test_to_int_invalid_input():
     assert _to_int("") == 0
     assert _to_int(None) == 0
 
+
+def test_to_int_invalid_input_none():
+    assert _to_int("abc", none_on_error=True) is None
+    assert _to_int("", none_on_error=True) == 0
+    assert _to_int(None, none_on_error=True) == 0
+
+
+def test_to_int_valid_with_flag():
+    assert _to_int("10", none_on_error=True) == 10
+    assert _to_int("10.5", none_on_error=True) == 10
+

--- a/utils.py
+++ b/utils.py
@@ -1,19 +1,32 @@
 from decimal import Decimal, InvalidOperation
+from typing import Optional
 
 
-def _to_decimal(value: str) -> Decimal:
-    """Convert user input to ``Decimal``. Returns ``Decimal('0')`` on error."""
+def _to_decimal(value: str, *, none_on_error: bool = False) -> Optional[Decimal]:
+    """Convert user input to ``Decimal``.
+
+    When ``none_on_error`` is ``True``, ``None`` is returned for invalid values.
+    Empty strings and ``None`` are treated as ``Decimal('0')`` regardless of the
+    flag.
+    """
     if value is None or value == "":
         return Decimal("0")
     try:
         return Decimal(value.replace(",", "."))
     except (InvalidOperation, AttributeError):
-        return Decimal("0")
+        return None if none_on_error else Decimal("0")
 
 
-def _to_int(value: str) -> int:
-    """Convert user input to ``int``. Returns ``0`` on error."""
+def _to_int(value: str, *, none_on_error: bool = False) -> Optional[int]:
+    """Convert user input to ``int``.
+
+    When ``none_on_error`` is ``True``, ``None`` is returned for invalid values.
+    Empty strings and ``None`` are treated as ``0`` regardless of the flag.
+    """
+    dec = _to_decimal(value, none_on_error=none_on_error)
+    if dec is None:
+        return None if none_on_error else 0
     try:
-        return int(_to_decimal(value))
+        return int(dec)
     except (InvalidOperation, ValueError):
-        return 0
+        return None if none_on_error else 0


### PR DESCRIPTION
## Summary
- extend `_to_decimal` and `_to_int` with `none_on_error` parameter
- guard against invalid numeric values in the Streamlit app
- add unit tests for the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684559561c90832c965cb6cc29a91d5b