### PR TITLE
Remove redundant rerun in tab switch handler

### DIFF
--- a/app.py
+++ b/app.py
@@ -185,7 +185,9 @@ def _on_tab_change() -> None:
         clear_quick_all()
         st.session_state["selected_tab"] = new_key
         st.query_params.update({"tab": new_key})
-        st.rerun()
+        # rerun to refresh the UI is no longer needed as the radio widget
+        # handles tab switching without a warning
+        # st.rerun()
 
 
 st.radio(


### PR DESCRIPTION
## Summary
- avoid calling `st.rerun()` when switching tabs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68455ba9e380832c88714a91a3bd6d24