### PR TITLE
Add basic pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.9.1
+    hooks:
+      - id: black
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer

--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ The application supports both Polish and English languages and runs entirely in 
 
 ## Setup
 
-Install the required packages and start the application:
+Install the required packages and set up the pre-commit hooks before starting the application:
 
 ```bash
 pip install -r requirements.txt
+pip install pre-commit
+pre-commit install
 streamlit run app.py
 ```
 


### PR DESCRIPTION
## Summary
- add `.pre-commit-config.yaml` with `black` and `isort`
- document `pre-commit` setup in README

## Testing
- `pytest -q`
- `pip install pre-commit` *(fails: Could not find a version)*

------
https://chatgpt.com/codex/tasks/task_e_68456564e628832cbf1f849fc9a7de2e