### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+EXPOSE 8501
+CMD ["streamlit", "run", "app.py", "--server.port", "8501", "--server.address", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -50,3 +50,22 @@ Calculate sale price from a desired margin:
 python cli.py cena 50 0.2
 ```
 
+## Docker
+
+The repository includes a `Dockerfile` so the application can be run in a
+container without installing Python locally.
+
+Build the image with:
+
+```bash
+docker build -t margin-calculator .
+```
+
+Then start the container:
+
+```bash
+docker run -p 8501:8501 margin-calculator
+```
+
+Once running, open `http://localhost:8501` in your browser to use the app.
+


### PR DESCRIPTION
## Summary
- include Dockerfile to containerise the app
- document container build and run instructions in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684568d9812c832c8a323d8633c5d312