### PR TITLE
Configure Streamlit layout via config file

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,8 @@
+[theme]
+primaryColor = "#F63366"
+backgroundColor = "#FFFFFF"
+secondaryBackgroundColor = "#F0F2F6"
+textColor = "#262730"
+font = "sans serif"
+
+layout = "wide"

--- a/app.py
+++ b/app.py
@@ -6,7 +6,6 @@ from utils import _to_decimal, _to_int
 st.set_page_config(
     page_title="Kalkulator Marży / Margin Calculator",
     page_icon="💰",
-    layout="centered",
 )
 
 # Prevent button labels from wrapping


### PR DESCRIPTION
## Summary
- add `.streamlit/config.toml` with theme settings and wide layout
- remove hardcoded `layout="centered"` from `st.set_page_config` so Streamlit uses config file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845707d686c832c986ee8faf21d49aa