### PR TITLE
Add module docstrings and reorder imports

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,9 @@
-import streamlit as st
+"""Streamlit application for interactive margin calculations."""
+
 from decimal import Decimal
+import streamlit as st
 from utils import _to_decimal, _to_int
+from calculator import licz_marze_z_ceny, cena_z_marzy
 
 # ------------------ Konfiguracja / Config ------------------
 st.set_page_config(
@@ -162,10 +165,6 @@ def _entered(key: str) -> bool:
     """Return ``True`` if the user explicitly provided a value for ``key``."""
     val = st.session_state.get(key, "")
     return str(val).strip() != ""
-
-# ------------------ Funkcje matematyczne -------------------
-
-from calculator import licz_marze_z_ceny, cena_z_marzy
 
 # ------------------ UI -------------------------------------
 st.title(T["title"])

--- a/calculator.py
+++ b/calculator.py
@@ -1,3 +1,5 @@
+"""Helper functions performing margin-related calculations."""
+
 from decimal import Decimal
 
 

--- a/cli.py
+++ b/cli.py
@@ -1,3 +1,5 @@
+"""Command line utilities for the margin calculator."""
+
 import argparse
 from decimal import Decimal
 


### PR DESCRIPTION
## Summary
- document main modules with simple module-level docstrings
- move the math helper import to the top of `app.py`
- reorder imports so `decimal.Decimal` appears before `streamlit`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684578621ec0832cba9ccc29fae17d5f