### PR TITLE
Fix test file trailing blank lines

### DIFF
--- a/tests/test_to_decimal.py
+++ b/tests/test_to_decimal.py
@@ -26,4 +26,3 @@ def test_to_decimal_invalid_string_none():
 def test_to_decimal_valid_with_flag():
     assert _to_decimal("10.5", none_on_error=True) == Decimal("10.5")
     assert _to_decimal("10,5", none_on_error=True) == Decimal("10.5")
-

--- a/tests/test_to_int.py
+++ b/tests/test_to_int.py
@@ -22,4 +22,3 @@ def test_to_int_invalid_input_none():
 def test_to_int_valid_with_flag():
     assert _to_int("10", none_on_error=True) == 10
     assert _to_int("10.5", none_on_error=True) == 10
-


### PR DESCRIPTION
## Summary
- remove stray newline at the end of `tests/test_to_decimal.py`
- remove stray newline at the end of `tests/test_to_int.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684581c960c8832c9ebf8eb4eff35ecd