### PR TITLE
Add forms to discount and quick sections

### DIFF
--- a/app.py
+++ b/app.py
@@ -216,99 +216,101 @@ st.radio(
 # ========= Zakładka 1: obniżka marży / ceny ================
 if st.session_state["selected_tab"] == "discount":
     st.header(T["discount_header"])
-
-    col_a, col_or1, col_b = st.columns([1, 0.15, 1])
-    with col_a:
-        tkw = st.number_input(T["tkw"], key="tkw", value=0.0)
-        sub_a1, sub_a2, sub_a3 = st.columns([1,1,1])
-        with sub_a2:
-            st.button(
-                T["btn_clear"],
-                key="clr_tkw",
-                on_click=_clear_field,
-                args=("tkw", INITIAL_DISCOUNT),
+    with st.form("discount_form"):
+    
+        col_a, col_or1, col_b = st.columns([1, 0.15, 1])
+        with col_a:
+            tkw = st.number_input(T["tkw"], key="tkw", value=0.0)
+            sub_a1, sub_a2, sub_a3 = st.columns([1,1,1])
+            with sub_a2:
+                st.form_submit_button(
+                    T["btn_clear"],
+                    key="clr_tkw",
+                    on_click=_clear_field,
+                    args=("tkw", INITIAL_DISCOUNT),
+                )
+        with col_or1:
+            or_html = (
+                f"<div style='text-align:center; padding-top:2.3rem; font-weight:700;'>{T['or']}</div>"
             )
-    with col_or1:
-        or_html = (
-            f"<div style='text-align:center; padding-top:2.3rem; font-weight:700;'>{T['or']}</div>"
-        )
-        st.markdown(or_html, unsafe_allow_html=True)
-    with col_b:
-        cena_stara = st.number_input(T["price"], key="cena_stara", value=0.0)
-        sub_b1, sub_b2, sub_b3 = st.columns([1,1,1])
-        with sub_b2:
-            st.button(
-                T["btn_clear"],
-                key="clr_cena_stara",
-                on_click=_clear_field,
-                args=("cena_stara", INITIAL_DISCOUNT),
+            st.markdown(or_html, unsafe_allow_html=True)
+        with col_b:
+            cena_stara = st.number_input(T["price"], key="cena_stara", value=0.0)
+            sub_b1, sub_b2, sub_b3 = st.columns([1,1,1])
+            with sub_b2:
+                st.form_submit_button(
+                    T["btn_clear"],
+                    key="clr_cena_stara",
+                    on_click=_clear_field,
+                    args=("cena_stara", INITIAL_DISCOUNT),
+                )
+    
+        col_c, col_or2, col_d = st.columns([1, 0.15, 1])
+        with col_c:
+            marza_stara = st.number_input(T["old_margin"], key="marza_stara", value=0.0)
+            sub_c1, sub_c2, sub_c3 = st.columns([1,1,1])
+            with sub_c2:
+                st.form_submit_button(
+                    T["btn_clear"],
+                    key="clr_marza_stara",
+                    on_click=_clear_field,
+                    args=("marza_stara", INITIAL_DISCOUNT),
+                )
+        with col_or2:
+            st.markdown(or_html, unsafe_allow_html=True)
+        with col_d:
+            cena_nowa = st.number_input(T["new_price"], key="cena_nowa", value=0.0)
+            sub_d1, sub_d2, sub_d3 = st.columns([1,1,1])
+            with sub_d2:
+                st.form_submit_button(
+                    T["btn_clear"],
+                    key="clr_cena_nowa",
+                    on_click=_clear_field,
+                    args=("cena_nowa", INITIAL_DISCOUNT),
+                )
+    
+        col_e, col_f = st.columns([1, 1])
+        with col_e:
+            marza_nowa = st.number_input(T["new_margin"], key="marza_nowa", value=0.0)
+            sub_e1, sub_e2, sub_e3 = st.columns([1,1,1])
+            with sub_e2:
+                st.form_submit_button(
+                    T["btn_clear"],
+                    key="clr_marza_nowa",
+                    on_click=_clear_field,
+                    args=("marza_nowa", INITIAL_DISCOUNT),
+                )
+        with col_f:
+            ilosc_stara = st.number_input(T["qty"], key="ilosc_stara", value=0, step=1)
+            sub_f1, sub_f2, sub_f3 = st.columns([1,1,1])
+            with sub_f2:
+                st.form_submit_button(
+                    T["btn_clear"],
+                    key="clr_ilosc_stara",
+                    on_click=_clear_field,
+                    args=("ilosc_stara", INITIAL_DISCOUNT),
+                )
+    
+        col_actions_d1, col_actions_d2 = st.columns([1, 1])
+        with col_actions_d1:
+            st.form_submit_button(
+                T["btn_clear_all"],
+                key="clear_all_discount",
+                on_click=clear_discount_all,
             )
-
-    col_c, col_or2, col_d = st.columns([1, 0.15, 1])
-    with col_c:
-        marza_stara = st.number_input(T["old_margin"], key="marza_stara", value=0.0)
-        sub_c1, sub_c2, sub_c3 = st.columns([1,1,1])
-        with sub_c2:
-            st.button(
-                T["btn_clear"],
-                key="clr_marza_stara",
-                on_click=_clear_field,
-                args=("marza_stara", INITIAL_DISCOUNT),
+        with col_actions_d2:
+            st.form_submit_button(
+                T["btn_example"],
+                key="example_discount",
+                on_click=load_discount_example,
             )
-    with col_or2:
-        st.markdown(or_html, unsafe_allow_html=True)
-    with col_d:
-        cena_nowa = st.number_input(T["new_price"], key="cena_nowa", value=0.0)
-        sub_d1, sub_d2, sub_d3 = st.columns([1,1,1])
-        with sub_d2:
-            st.button(
-                T["btn_clear"],
-                key="clr_cena_nowa",
-                on_click=_clear_field,
-                args=("cena_nowa", INITIAL_DISCOUNT),
-            )
-
-    col_e, col_f = st.columns([1, 1])
-    with col_e:
-        marza_nowa = st.number_input(T["new_margin"], key="marza_nowa", value=0.0)
-        sub_e1, sub_e2, sub_e3 = st.columns([1,1,1])
-        with sub_e2:
-            st.button(
-                T["btn_clear"],
-                key="clr_marza_nowa",
-                on_click=_clear_field,
-                args=("marza_nowa", INITIAL_DISCOUNT),
-            )
-    with col_f:
-        ilosc_stara = st.number_input(T["qty"], key="ilosc_stara", value=0, step=1)
-        sub_f1, sub_f2, sub_f3 = st.columns([1,1,1])
-        with sub_f2:
-            st.button(
-                T["btn_clear"],
-                key="clr_ilosc_stara",
-                on_click=_clear_field,
-                args=("ilosc_stara", INITIAL_DISCOUNT),
-            )
-
-    col_actions_d1, col_actions_d2 = st.columns([1, 1])
-    with col_actions_d1:
-        st.button(
-            T["btn_clear_all"],
-            key="clear_all_discount",
-            on_click=clear_discount_all,
-        )
-    with col_actions_d2:
-        st.button(
-            T["btn_example"],
-            key="example_discount",
-            on_click=load_discount_example,
-        )
-
-    if st.button(T["btn_discount"], key="discount_btn"):
+    
+        submitted_discount = st.form_submit_button(T["btn_discount"], key="discount_btn")
+    if submitted_discount:
         if None in (tkw, cena_stara, marza_stara, cena_nowa, marza_nowa, ilosc_stara):
             st.error("Invalid input")
             st.stop()
-
+    
         if not _entered("tkw") or not _entered("ilosc_stara"):
             st.error(T["err_fill"])
             st.stop()
@@ -365,71 +367,73 @@ if st.session_state["selected_tab"] == "discount":
 # ========= Zakładka 2: szybki kalkulator ====================
 elif st.session_state["selected_tab"] == "quick":
     st.header(T["quick_header"])
-    or_html = (
-        f"<div style='text-align:center; padding-top:2.3rem; font-weight:700;'>{T['or']}</div>"
-    )
-    st.markdown(
-        f"<div style='text-align:center;font-size:0.75em;color:gray'>{T['quick_sub']}</div>",
-        unsafe_allow_html=True,
-    )
-
-    col_tkw, col_or_a, col_price, col_or_b, col_margin = st.columns(
-        [1, 0.13, 1, 0.13, 1]
-    )
-    with col_tkw:
-        tkw_m = st.number_input(T["tkw"], key="tkw_m", value=0.0)
-        sub_q1, sub_q2, sub_q3 = st.columns([1,1,1])
-        with sub_q2:
-            st.button(
-                T["btn_clear"],
-                key="clr_tkw_m",
-                on_click=_clear_field,
-                args=("tkw_m", INITIAL_QUICK),
-            )
-    with col_or_a:
-        st.markdown(or_html, unsafe_allow_html=True)
-    with col_price:
-        cena_m = st.number_input(T["price"], key="cena_m", value=0.0)
-        sub_q4, sub_q5, sub_q6 = st.columns([1,1,1])
-        with sub_q5:
-            st.button(
-                T["btn_clear"],
-                key="clr_cena_m",
-                on_click=_clear_field,
-                args=("cena_m", INITIAL_QUICK),
-            )
-    with col_or_b:
-        st.markdown(or_html, unsafe_allow_html=True)
-    with col_margin:
-        marza_m = st.number_input(
-            T["new_margin"].replace("Nowa ", "").replace("New ", "").capitalize(),
-            key="marza_m",
-            value=0.0,
+    with st.form("quick_form"):
+        or_html = (
+            f"<div style='text-align:center; padding-top:2.3rem; font-weight:700;'>{T['or']}</div>"
         )
-        sub_q7, sub_q8, sub_q9 = st.columns([1,1,1])
-        with sub_q8:
-            st.button(
-                T["btn_clear"],
-                key="clr_marza_m",
-                on_click=_clear_field,
-                args=("marza_m", INITIAL_QUICK),
+        st.markdown(
+            f"<div style='text-align:center;font-size:0.75em;color:gray'>{T['quick_sub']}</div>",
+            unsafe_allow_html=True,
+        )
+    
+        col_tkw, col_or_a, col_price, col_or_b, col_margin = st.columns(
+            [1, 0.13, 1, 0.13, 1]
+        )
+        with col_tkw:
+            tkw_m = st.number_input(T["tkw"], key="tkw_m", value=0.0)
+            sub_q1, sub_q2, sub_q3 = st.columns([1,1,1])
+            with sub_q2:
+                st.form_submit_button(
+                    T["btn_clear"],
+                    key="clr_tkw_m",
+                    on_click=_clear_field,
+                    args=("tkw_m", INITIAL_QUICK),
+                )
+        with col_or_a:
+            st.markdown(or_html, unsafe_allow_html=True)
+        with col_price:
+            cena_m = st.number_input(T["price"], key="cena_m", value=0.0)
+            sub_q4, sub_q5, sub_q6 = st.columns([1,1,1])
+            with sub_q5:
+                st.form_submit_button(
+                    T["btn_clear"],
+                    key="clr_cena_m",
+                    on_click=_clear_field,
+                    args=("cena_m", INITIAL_QUICK),
+                )
+        with col_or_b:
+            st.markdown(or_html, unsafe_allow_html=True)
+        with col_margin:
+            marza_m = st.number_input(
+                T["new_margin"].replace("Nowa ", "").replace("New ", "").capitalize(),
+                key="marza_m",
+                value=0.0,
             )
-
-    col_actions_q1, col_actions_q2 = st.columns([1, 1])
-    with col_actions_q1:
-        st.button(
-            T["btn_clear_all"],
-            key="clear_all_quick",
-            on_click=clear_quick_all,
-        )
-    with col_actions_q2:
-        st.button(
-            T["btn_example"],
-            key="example_quick",
-            on_click=load_quick_example,
-        )
-
-    if st.button(T["btn_quick"], key="quick_btn"):
+            sub_q7, sub_q8, sub_q9 = st.columns([1,1,1])
+            with sub_q8:
+                st.form_submit_button(
+                    T["btn_clear"],
+                    key="clr_marza_m",
+                    on_click=_clear_field,
+                    args=("marza_m", INITIAL_QUICK),
+                )
+    
+        col_actions_q1, col_actions_q2 = st.columns([1, 1])
+        with col_actions_q1:
+            st.form_submit_button(
+                T["btn_clear_all"],
+                key="clear_all_quick",
+                on_click=clear_quick_all,
+            )
+        with col_actions_q2:
+            st.form_submit_button(
+                T["btn_example"],
+                key="example_quick",
+                on_click=load_quick_example,
+            )
+    
+        submitted_quick = st.form_submit_button(T["btn_quick"], key="quick_btn")
+    if submitted_quick:
         if None in (tkw_m, cena_m, marza_m):
             st.error("Invalid input")
             st.stop()


### PR DESCRIPTION
## Summary
- wrap discount inputs and actions with `st.form("discount_form")`
- use `st.form_submit_button` for discount operations
- wrap quick calculator section in `st.form("quick_form")`
- use `st.form_submit_button` for quick calculator buttons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845af1282ac832c9842dda9040e6cc3