### PR TITLE
Remove form button keys

### DIFF
--- a/app.py
+++ b/app.py
@@ -227,7 +227,6 @@ if st.session_state["selected_tab"] == "discount":
             with sub_a2:
                 st.form_submit_button(
                     T["btn_clear"],
-                    key="clr_tkw",
                     on_click=_clear_field,
                     args=("tkw", INITIAL_DISCOUNT),
                 )
@@ -240,7 +239,6 @@ if st.session_state["selected_tab"] == "discount":
             with sub_b2:
                 st.form_submit_button(
                     T["btn_clear"],
-                    key="clr_cena_stara",
                     on_click=_clear_field,
                     args=("cena_stara", INITIAL_DISCOUNT),
                 )
@@ -252,7 +250,6 @@ if st.session_state["selected_tab"] == "discount":
             with sub_c2:
                 st.form_submit_button(
                     T["btn_clear"],
-                    key="clr_marza_stara",
                     on_click=_clear_field,
                     args=("marza_stara", INITIAL_DISCOUNT),
                 )
@@ -264,7 +261,6 @@ if st.session_state["selected_tab"] == "discount":
             with sub_d2:
                 st.form_submit_button(
                     T["btn_clear"],
-                    key="clr_cena_nowa",
                     on_click=_clear_field,
                     args=("cena_nowa", INITIAL_DISCOUNT),
                 )
@@ -276,7 +272,6 @@ if st.session_state["selected_tab"] == "discount":
             with sub_e2:
                 st.form_submit_button(
                     T["btn_clear"],
-                    key="clr_marza_nowa",
                     on_click=_clear_field,
                     args=("marza_nowa", INITIAL_DISCOUNT),
                 )
@@ -286,7 +281,6 @@ if st.session_state["selected_tab"] == "discount":
             with sub_f2:
                 st.form_submit_button(
                     T["btn_clear"],
-                    key="clr_ilosc_stara",
                     on_click=_clear_field,
                     args=("ilosc_stara", INITIAL_DISCOUNT),
                 )
@@ -295,18 +289,16 @@ if st.session_state["selected_tab"] == "discount":
         with col_actions_d1:
             st.form_submit_button(
                 T["btn_clear_all"],
-                key="clear_all_discount",
                 on_click=clear_discount_all,
             )
         with col_actions_d2:
             st.form_submit_button(
                 T["btn_example"],
-                key="example_discount",
                 on_click=load_discount_example,
             )
 
         submitted_discount = st.form_submit_button(
-            T["btn_discount"], key="discount_btn"
+            T["btn_discount"]
         )
     if submitted_discount:
         with st.spinner("Obliczanie..."):
@@ -393,7 +385,6 @@ elif st.session_state["selected_tab"] == "quick":
             with sub_q2:
                 st.form_submit_button(
                     T["btn_clear"],
-                    key="clr_tkw_m",
                     on_click=_clear_field,
                     args=("tkw_m", INITIAL_QUICK),
                 )
@@ -405,7 +396,6 @@ elif st.session_state["selected_tab"] == "quick":
             with sub_q5:
                 st.form_submit_button(
                     T["btn_clear"],
-                    key="clr_cena_m",
                     on_click=_clear_field,
                     args=("cena_m", INITIAL_QUICK),
                 )
@@ -421,7 +411,6 @@ elif st.session_state["selected_tab"] == "quick":
             with sub_q8:
                 st.form_submit_button(
                     T["btn_clear"],
-                    key="clr_marza_m",
                     on_click=_clear_field,
                     args=("marza_m", INITIAL_QUICK),
                 )
@@ -430,17 +419,15 @@ elif st.session_state["selected_tab"] == "quick":
         with col_actions_q1:
             st.form_submit_button(
                 T["btn_clear_all"],
-                key="clear_all_quick",
                 on_click=clear_quick_all,
             )
         with col_actions_q2:
             st.form_submit_button(
                 T["btn_example"],
-                key="example_quick",
                 on_click=load_quick_example,
             )
 
-        submitted_quick = st.form_submit_button(T["btn_quick"], key="quick_btn")
+        submitted_quick = st.form_submit_button(T["btn_quick"])
     if submitted_quick:
         with st.spinner("Obliczanie..."):
             if None in (tkw_m, cena_m, marza_m):


### PR DESCRIPTION
## Summary
- strip `key` parameter from `form_submit_button` calls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845b6fe3e9c832c9d5cf52c654854e8