### PR TITLE
Fix CLI import path

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3,7 +3,7 @@
 import argparse
 from decimal import Decimal
 
-from calculator import cena_z_marzy, licz_marze_z_ceny
+from margin_calculator.calculator import cena_z_marzy, licz_marze_z_ceny
 
 
 def main() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,4 @@ version = "0.1.0"
 dependencies = [
     "streamlit==1.45.1",
 ]
+packages = ["margin_calculator"]


### PR DESCRIPTION
## Summary
- point CLI to the packaged calculator module
- include packages in `pyproject.toml` for distribution

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845bb15a6f0832c845587d12dfa85e6