### PR TITLE
Remove Streamlit caching decorators

### DIFF
--- a/calculator.py
+++ b/calculator.py
@@ -2,10 +2,7 @@
 
 from decimal import Decimal
 
-import streamlit as st
 
-
-@st.cache_data
 def licz_marze_z_ceny(tkw: Decimal, cena: Decimal) -> Decimal:
     """Return the margin as a fraction of ``cena``.
 
@@ -30,7 +27,6 @@ def licz_marze_z_ceny(tkw: Decimal, cena: Decimal) -> Decimal:
     return (cena - tkw) / cena if cena else Decimal("0")
 
 
-@st.cache_data
 def cena_z_marzy(tkw: Decimal, marza: Decimal) -> Decimal:
     """Return the sale price required to achieve ``marza``.
 


### PR DESCRIPTION
## Summary
- drop `streamlit` import from calculator module
- remove `@st.cache_data` decorators

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845be26953c832cbc7ec39f8d520b7e