### PR TITLE
Use package imports

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 
 import streamlit as st
 
-from calculator import cena_z_marzy, licz_marze_z_ceny
+from margin_calculator.calculator import cena_z_marzy, licz_marze_z_ceny
 
 # ------------------ Konfiguracja / Config ------------------
 st.set_page_config(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,4 +8,8 @@ version = "0.1.0"
 dependencies = [
     "streamlit==1.45.1",
 ]
+
+[tool.setuptools]
 packages = ["margin_calculator"]
+[tool.setuptools.package-dir]
+margin_calculator = "."

--- a/tests/test_calculations.py
+++ b/tests/test_calculations.py
@@ -1,7 +1,7 @@
 import unittest
 from decimal import Decimal
 
-from calculator import licz_marze_z_ceny, cena_z_marzy
+from margin_calculator.calculator import licz_marze_z_ceny, cena_z_marzy
 
 
 class TestMarginFunctions(unittest.TestCase):


### PR DESCRIPTION
## Summary
- import margin helpers using package name
- allow setuptools to map the package to the repo root

## Testing
- `pytest -q`
- `pip install -e . --no-build-isolation` *(fails: invalid command 'bdist_wheel')*

------
https://chatgpt.com/codex/tasks/task_e_6845c4713738832c9e184761834755b5