### PR TITLE
Fix streamlit import error

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,10 @@ from decimal import Decimal
 
 import streamlit as st
 
-from margin_calculator.calculator import cena_z_marzy, licz_marze_z_ceny
+try:  # Prefer relative import when installed as a package
+    from .calculator import cena_z_marzy, licz_marze_z_ceny
+except ImportError:  # Fallback for running as a standalone script
+    from calculator import cena_z_marzy, licz_marze_z_ceny
 
 # ------------------ Konfiguracja / Config ------------------
 st.set_page_config(

--- a/cli.py
+++ b/cli.py
@@ -3,7 +3,10 @@
 import argparse
 from decimal import Decimal
 
-from margin_calculator.calculator import cena_z_marzy, licz_marze_z_ceny
+try:  # Prefer relative import when installed as a package
+    from .calculator import cena_z_marzy, licz_marze_z_ceny
+except ImportError:  # Fallback for running as a standalone script
+    from calculator import cena_z_marzy, licz_marze_z_ceny
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- import helper functions using relative imports with fallback
- allow running app.py or cli.py directly without package installation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845c6808a04832cbcc9c9f242d27938