### PR TITLE
Add Pylint config and workflow update

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -21,4 +21,4 @@ jobs:
         pip install -r requirements.txt
     - name: Analysing the code with pylint
       run: |
-        pylint $(git ls-files '*.py')
+        pylint --rcfile=.pylintrc $(git ls-files '*.py')

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,5 @@
+[MESSAGES CONTROL]
+disable=missing-module-docstring
+
+[FORMAT]
+max-line-length=88


### PR DESCRIPTION
## Summary
- add project-wide `.pylintrc` disabling `missing-module-docstring` and set max line length to 88
- reference the config in the Pylint workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845f1a446ac832ca158472067d5b458