### PR TITLE
Configure CLI script entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ dependencies = [
     "streamlit==1.45.1",
 ]
 
+[project.scripts]
+margin-calc = "margin_calculator.cli:main"
+
 [tool.setuptools]
 packages = ["margin_calculator"]
 [tool.setuptools.package-dir]


### PR DESCRIPTION
## Summary
- add CLI script mapping in `pyproject.toml`

## Testing
- `pytest -q`
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845f4b817ec832c89b1ae54f41722d4