### PR TITLE
Add uniform styling for number inputs

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,6 +22,26 @@ st.markdown(
     unsafe_allow_html=True,
 )
 
+# Ensure uniform size and centered text for all number inputs
+st.markdown(
+    """
+    <style>
+        div.stNumberInput>label {
+            display: block;
+            text-align: center;
+            white-space: nowrap;
+        }
+        div.stNumberInput input {
+            text-align: center;
+        }
+        div.stNumberInput>div {
+            width: 100%;
+        }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
 # Compatibility helper for older Streamlit versions.
 _fsb_params = inspect.signature(st.form_submit_button).parameters
 


### PR DESCRIPTION
## Summary
- ensure all number inputs have consistent width and centered labels

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68472ba68718832ca15050f9f2ae533f