### PR TITLE
Update quick calc subtitle font

### DIFF
--- a/app.py
+++ b/app.py
@@ -429,7 +429,7 @@ elif st.session_state["selected_tab"] == "quick":
     with st.form("quick_form"):
         or_html = f"<div style='text-align:center; padding-top:2.3rem; font-weight:700;'>{T['or']}</div>"
         st.markdown(
-            f"<div style='text-align:center;font-size:0.75em;color:gray'>{T['quick_sub']}</div>",
+            f"<div style='text-align:center;font-size:0.75em;color:gray;font-family:var(--font);'>{T['quick_sub']}</div>",
             unsafe_allow_html=True,
         )
 


### PR DESCRIPTION
## Summary
- ensure quick calculator subtitle uses the same font as headers

## Testing
- `pytest -q`
- `streamlit run app.py` *(fails: not accessible in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_684739104428832c8b8c27258b1a0216