### PR TITLE
Improve zero field clearing

### DIFF
--- a/app.py
+++ b/app.py
@@ -262,7 +262,7 @@ def number_input_with_clear(label: str, key: str, init_dict: dict, **kwargs) -> 
             if (el) {{
                 el.id = '{key}';
                 const clearIfZero = () => {{
-                    if (el.value === '0') {{
+                    if (el.value !== '' && parseFloat(el.value) === 0) {{
                         el.value = '';
                     }}
                 }};


### PR DESCRIPTION
## Summary
- avoid leftover zeros in number inputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68487911b580832c93e9e26a9915bdf2