### PR TITLE
Fix number input clearing

### DIFF
--- a/app.py
+++ b/app.py
@@ -258,8 +258,10 @@ def number_input_with_clear(label: str, key: str, init_dict: dict, **kwargs) -> 
         <script>
         (() => {{
             const inputs = window.document.querySelectorAll('div[data-testid="stNumberInput"] input[type=number]');
-            const el = inputs[inputs.length - 1];
+            window._numInputIdx = (window._numInputIdx || 0);
+            const el = inputs[window._numInputIdx];
             if (el) {{
+                window._numInputIdx += 1;
                 el.id = '{key}';
                 const clearIfZero = () => {{
                     if (!el.dataset.cleared && el.value !== '' && parseFloat(el.value) === 0) {{


### PR DESCRIPTION
## Summary
- fix JS that clears the default zero when focusing number inputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68487c80a5c4832cb9d28c0e849be8d2