### PR TITLE
Remove default zeros on load

### DIFF
--- a/app.py
+++ b/app.py
@@ -250,9 +250,9 @@ def number_input_with_clear(label: str, key: str, init_dict: dict, **kwargs) -> 
     """Return a ``Decimal`` from a number input with a centered clear button."""
     val = st.number_input(label, key=key, **kwargs)
 
-    # assign an HTML id and attach JS to clear the default zero value when the
-    # field receives focus or a key press. We select the last number input which
-    # corresponds to the widget just created above.
+    # assign an HTML id and attach JS to clear the default zero value. We
+    # select the last number input which corresponds to the widget just created
+    # above.
     st.markdown(
         f"""
         <script>
@@ -266,6 +266,8 @@ def number_input_with_clear(label: str, key: str, init_dict: dict, **kwargs) -> 
                         el.value = '';
                     }}
                 }};
+                // Clear immediately so users don't see the default 0 value
+                clearIfZero();
                 el.addEventListener('focus', clearIfZero);
             }}
         }})();


### PR DESCRIPTION
## Summary
- ensure number inputs start blank so users don't see default `0`
- run all tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68488279339c832cb23f8a8b0adfaa72