### PR TITLE
Fix example fields to avoid zero profit error

### DIFF
--- a/app.py
+++ b/app.py
@@ -164,17 +164,17 @@ INITIAL_QUICK = {
 EXAMPLE_DISCOUNT_PRICE = {
     "tkw": 80.0,
     "cena_stara": 120.0,
-    "marza_stara": 0.0,
+    "marza_stara": None,
     "cena_nowa": 100.0,
-    "marza_nowa": 0.0,
+    "marza_nowa": None,
     "ilosc_stara": 100,
 }
 
 EXAMPLE_DISCOUNT_MARGIN = {
     "tkw": 80.0,
-    "cena_stara": 0.0,
+    "cena_stara": None,
     "marza_stara": 40.0,
-    "cena_nowa": 0.0,
+    "cena_nowa": None,
     "marza_nowa": 20.0,
     "ilosc_stara": 100,
 }

--- a/tests/test_calculations.py
+++ b/tests/test_calculations.py
@@ -59,6 +59,22 @@ class TestMarginFunctions(unittest.TestCase):
         strata = (zysk_stary - zysk_nowy) * qty
         self.assertEqual(strata, Decimal('3333'))
 
+    def test_example_discount_price_positive_profit(self):
+        """Example with price inputs should yield positive profit after drop."""
+        tkw = Decimal('80')
+        cena_stara = Decimal('120')
+        cena_nowa = Decimal('100')
+
+        marza_stara = licz_marze_z_ceny(tkw, cena_stara) * 100
+        marza_nowa = licz_marze_z_ceny(tkw, cena_nowa) * 100
+
+        zysk_stary = cena_stara - tkw
+        zysk_nowy = cena_nowa - tkw
+
+        self.assertEqual(marza_stara, Decimal('33.33333333333333333333333333'))
+        self.assertEqual(marza_nowa, Decimal('20'))
+        self.assertGreater(zysk_nowy, Decimal('0'))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- fill example inputs with `None` for unused fields
- add test ensuring example discount scenario gives positive profit

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684887f0960c832c915f05a541d9a855