### PR TITLE
Adjust quick calc header size

### DIFF
--- a/app.py
+++ b/app.py
@@ -431,7 +431,7 @@ elif st.session_state["selected_tab"] == "quick":
     with st.form("quick_form"):
         or_html = f"<div style='text-align:center; padding-top:2.3rem; font-weight:700;'>{T['or']}</div>"
         st.markdown(
-            f"<div style='text-align:center;font-size:0.75em;color:gray;font-family:var(--font);'>{T['quick_sub']}</div>",
+            f"<div style='text-align:center;font-size:1.5em;color:gray;font-family:var(--font);'>{T['quick_sub']}</div>",
             unsafe_allow_html=True,
         )
 


### PR DESCRIPTION
## Summary
- enlarge the quick calculator subtitle font

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b1b689514832ca75601d815c0b146